### PR TITLE
Fix to support the ng-strict-di directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "author": "Yves Mancera",
-  "name": "loading-dots",
+  "name": "angular-loading-dots",
   "description": "Loading-dots - An AngularJS directive to display loading dots in the form of text",
   "version": "0.0.1",
+  "main": "./src/loading-dots.js",
   "homepage": "http://github.com/yvesmh/loading-dots/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jshint-stylish": "^0.2.0",
     "karma": "^0.12.31",
     "karma-jasmine": "^0.3.5",
-    "karma-phantomjs-launcher": "^0.1.4",
-    "phantomjs": "^1.9.15"
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.4"
   }
 }

--- a/src/loading-dots.js
+++ b/src/loading-dots.js
@@ -7,7 +7,7 @@
  * # loadingDots
  */
 angular.module('angularLoadingDots', [])
-  .directive('loadingDots', function ($interval) {
+  .directive('loadingDots', ["$interval", function ($interval) {
 
     /**
      * Repeats a character n times
@@ -123,4 +123,4 @@ angular.module('angularLoadingDots', [])
       restrict: 'AE',
       link: link
     };
-  });
+  }]);


### PR DESCRIPTION
Adds annotation for the $interval injection to pass the ng-strict-di check during runtime.

Without the fix, the directive will fail and its not safe for minification.
